### PR TITLE
Updated Compile function to parse S_ADO

### DIFF
--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -166,7 +166,7 @@ program Compile
 	* Find out where can I save the .mlib
 	* Try directories in order specified by S_ADO, skipping "." (current working directory)
 	* If all fail, then try working directory
-	tokenize "$S_ADO", parse(";")
+	tokenize `"$S_ADO"', parse(";")
 	local ok 0
 	while (!`ok') {
 

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -180,7 +180,7 @@ program Compile
 			continue
 		}
 		
-		if "`path'"!="." TrySave "`path'" "`1'" "`package'" "`functions'" `debug' `verbose'
+		if !inlist("`path'",".","") TrySave "`path'" "`1'" "`package'" "`functions'" `debug' `verbose'
 		
 		* Final effort: try installing to current directory
 		if(`"`1'"' == "" & !`ok') {

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -175,7 +175,10 @@ program Compile
 		else if `"`path'"'=="PERSONAL" local path `"`c(sysdir_personal)'"'
 		else if `"`path'"'=="OLDPLACE" local path `"`c(sysdir_oldplace)'"'
 		
-		if !inlist("`path'",".",";") TrySave "`path'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
+		cap dir `"`path'"'
+		if _rc continue
+		
+		if "`path'"!="." TrySave "`path'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
 		di "`path'"
 		
 		* Final effort: try installing to current directory
@@ -205,7 +208,7 @@ program TrySave
 		exit
 	}
 	else {
-		loc path = "`path'l/"
+		loc path = "`path'/l/"
 		cap conf new file "`path'`random_file'"
 		if (c(rc)) {
 			mkdir "`path'"

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -164,8 +164,8 @@ program Compile
 	*}
 	
 	* Find out where can I save the .mlib
-	* Try directories in order specified by S_ADO, skipping "." (current working directory)
-	* If all fail, then try working directory
+	* Try directories in order specified by S_ADO, skipping BASE/SITE/OLDPLACE
+	* If all fail, then try current working directory
 	tokenize `"$S_ADO"', parse(";")
 	local ok 0
 	while (!`ok') {
@@ -173,7 +173,6 @@ program Compile
 		local path `"`1'"'
 		if `"`path'"'=="PLUS" local path `"`c(sysdir_plus)'"'
 		else if `"`path'"'=="PERSONAL" local path `"`c(sysdir_personal)'"'
-		else if `"`path'"'=="OLDPLACE" local path `"`c(sysdir_oldplace)'"'
 		
 		mata : st_local("dir_ok", strofreal(direxists("`path'")))
 		if `dir_ok'==0 & `"`1'"' != ""{

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -169,17 +169,19 @@ program Compile
 	tokenize "$S_ADO", parse(";")
 	local ok 0
 	while (!`ok') {
-		
+
 		local path `"`1'"'
 		if `"`path'"'=="PLUS" local path `"`c(sysdir_plus)'"'
 		else if `"`path'"'=="PERSONAL" local path `"`c(sysdir_personal)'"'
 		else if `"`path'"'=="OLDPLACE" local path `"`c(sysdir_oldplace)'"'
 		
-		cap dir `"`path'"'
-		if _rc continue
+		mata : st_local("dir_ok", strofreal(direxists("`path'")))
+		if `dir_ok'==0 & `"`1'"' != ""{
+			macro shift
+			continue
+		}
 		
 		if "`path'"!="." TrySave "`path'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
-		di "`path'"
 		
 		* Final effort: try installing to current directory
 		if(`"`1'"' == "" & !`ok') {

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -166,13 +166,13 @@ program Compile
 		else if `"`path'"'=="PERSONAL" local path `"`c(sysdir_personal)'"'
 		
 		* Skip directories in S_ADO that do no exist or are not accessible
-		mata : st_local("dir_ok", strofreal(direxists("`path'")))
+		mata : st_local("dir_ok", strofreal(direxists(`"`path'"')))
 		if `dir_ok'==0 & `"`1'"' != ""{
 			macro shift
 			continue
 		}
 		
-		if !inlist("`path'",".","") TrySave "`path'" "`1'" "`package'" "`functions'" `debug' `verbose'
+		if !inlist(`"`path'"',".","") TrySave `"`path'"' "`1'" "`package'" "`functions'" `debug' `verbose'
 		
 		* Final effort after reaching end of S_ADO: try installing to current directory
 		if(`"`1'"' == "" & !`ok') {
@@ -193,7 +193,7 @@ program TrySave
 	args path name package functions debug verbose
 	assert "`package'"!=""
 	loc random_file = "`=int(runiform()*1e8)'"
-	cap conf new file "`path'/`random_file'"
+	cap conf new file `"`path'/`random_file'"'
 	if (c(rc)) {
 		di as error `"cannot save compiled Mata file in `name' (`path')"'
 		c_local ok 0

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -180,7 +180,7 @@ program Compile
 			continue
 		}
 		
-		if "`path'"!="." TrySave "`path'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
+		if "`path'"!="." TrySave "`path'" "`1'" "`package'" "`functions'" `debug' `verbose'
 		
 		* Final effort: try installing to current directory
 		if(`"`1'"' == "" & !`ok') {

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -203,7 +203,7 @@ program TrySave
 	args path name package functions debug verbose
 	assert "`package'"!=""
 	loc random_file = "`=int(runiform()*1e8)'"
-	cap conf new file "`path'`random_file'"
+	cap conf new file "`path'/`random_file'"
 	if (c(rc)) {
 		di as error `"cannot save compiled Mata file in `name' (`path')"'
 		c_local ok 0

--- a/src/ms_compile_mata.ado
+++ b/src/ms_compile_mata.ado
@@ -155,13 +155,42 @@ program Compile
 	if (`debug') mata: mata desc
 
 	* Find out where can I save the .mlib
-	TrySave "`c(sysdir_plus)'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
-	if (!`ok') TrySave "`c(sysdir_personal)'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
-	if (!`ok') TrySave "." "current path" "`package'" "`functions'" `debug' `verbose'
-	if (!`ok') {
-		di as error "Could not compile file; ftools will not work correctly"
-		error 123
+	*TrySave "`c(sysdir_plus)'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
+	*if (!`ok') TrySave "`c(sysdir_personal)'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
+	*if (!`ok') TrySave "." "current path" "`package'" "`functions'" `debug' `verbose'
+	*if (!`ok') {
+	*	di as error "Could not compile file; ftools will not work correctly"
+	*	error 123
+	*}
+	
+	* Find out where can I save the .mlib
+	* Try directories in order specified by S_ADO, skipping "." (current working directory)
+	* If all fail, then try working directory
+	tokenize "$S_ADO", parse(";")
+	local ok 0
+	while (!`ok') {
+		
+		local path `"`1'"'
+		if `"`path'"'=="PLUS" local path `"`c(sysdir_plus)'"'
+		else if `"`path'"'=="PERSONAL" local path `"`c(sysdir_personal)'"'
+		else if `"`path'"'=="OLDPLACE" local path `"`c(sysdir_oldplace)'"'
+		
+		if !inlist("`path'",".",";") TrySave "`path'" "sysdir_plus" "`package'" "`functions'" `debug' `verbose'
+		di "`path'"
+		
+		* Final effort: try installing to current directory
+		if(`"`1'"' == "" & !`ok') {
+			if (!`ok') TrySave "." "current path" "`package'" "`functions'" `debug' `verbose'
+			local ok = 1
+			
+			if (!`ok') {
+				di as error "Could not compile file; ftools will not work correctly"
+				error 123
+			}			
+		}
+		macro shift
 	}
+
 end
 
 

--- a/test/compile.do
+++ b/test/compile.do
@@ -11,11 +11,14 @@ net set ado "`c(sysdir_personal)'"
 
 *cap ado uninstall ftools, replace
 *net install ftools, from("https://github.com/reifjulian/ftools/raw/master/src/")
-net install ftools, from(https://github.com/sergiocorreia/ftools/raw/master/src/)
-mata: mata mlib index
+*net install ftools, from(https://github.com/sergiocorreia/ftools/raw/master/src/)
+*mata: mata mlib index
 
 ftools, compile
 
 di "`c(sysdir_plus)'"
 di "`c(sysdir_personal)'"
 di "`c(sysdir_oldplace)'"
+
+mata : st_numscalar("OK", direxists("C:\ado\personal\\"))
+di OK

--- a/test/compile.do
+++ b/test/compile.do
@@ -25,6 +25,7 @@ mata: mata mlib index
 ftools, compile
 confirm file "`c(sysdir_plus)'/l/lftools.mlib"
 ado uninstall ftools , from("`c(sysdir_plus)'")
+rm "`c(sysdir_plus)'/l/lftools.mlib"
 
 
 

--- a/test/compile.do
+++ b/test/compile.do
@@ -41,3 +41,16 @@ net install ftools, from(`"`netfrom'"')
 mata: mata mlib index
 ftools, compile
 confirm file "C:/custom_lib/l/lftools.mlib"
+erase "C:/custom_lib"
+
+* If there is nothing available (besides BASE/SITE/OLDPLACE, which are ignored), install to local dir
+adopath - 1
+mkdir workdir
+cd workdir
+net set ado "`c(pwd)'"
+cap ado uninstall ftools
+net install ftools, from(`"`netfrom'"')
+mata: mata mlib index
+ftools, compile
+confirm file "`c(pwd)'/l/lftools.mlib"
+erase "C:/custom_lib"

--- a/test/compile.do
+++ b/test/compile.do
@@ -21,11 +21,10 @@ if "`c(os)'"=="Windows" {
 	local deletion2 `"shell rmdir "wd" /s /q"'
 }
 
-else if "`c(os)'"=="OSX" {
-	local custom_lib ""
-	local deletion1 `"shell rm -r "`custom_lib'""'
+else if "`c(os)'"=="MacOSX" {
+	local custom_lib "~/custom_lib"
+	local deletion1 `"shell rm -r `custom_lib'"'
 	local deletion2 `"shell rm -r "wd""'
-	error 1
 }
 
 else if "`c(os)'"=="Unix" {

--- a/test/compile.do
+++ b/test/compile.do
@@ -42,24 +42,6 @@ else error 1
 * RUN TEST
 ***********
 
-* Robustness test: user adds nonsense paths to adopath (these should be ignored)
-mkdir "`custom_lib'"
-adopath ++ "`custom_lib'"
-net set ado "`custom_lib'"
-cap ado uninstall ftools
-net install ftools, from(`"`netfrom'"')
-mata: mata mlib index
-adopath ++ "C:/does_not_exist"
-adopath ++ "~32"
-adopath ++ `"dfh"i"'
-adopath + "z"
-
-ftools, compile
-confirm file "`custom_lib'/l/lftools.mlib"
-`deletion1'
-
-stop
-
 * Installing to PERSONAL
 net set ado "`c(sysdir_personal)'"
 cap ado uninstall ftools
@@ -109,4 +91,18 @@ cd ..
 `deletion2'
 
 
+* Robustness test: user adds nonsense paths to adopath (these should be ignored)
+mkdir "`custom_lib'"
+adopath ++ "`custom_lib'"
+net set ado "`custom_lib'"
+cap ado uninstall ftools
+net install ftools, from(`"`netfrom'"')
+mata: mata mlib index
+adopath ++ "C:/does_not_exist"
+adopath ++ "~32"
+adopath ++ `"dfh"i"'
+adopath + "z"
+ftools, compile
+confirm file "`custom_lib'/l/lftools.mlib"
+`deletion1'
 

--- a/test/compile.do
+++ b/test/compile.do
@@ -1,10 +1,3 @@
-
-* Note: This test script won't run on Mac or Linux because:
-* (1) creation of directory "C:/custom_lib"
-* (2) deletion of directories using `shell rmdir "mydir" /s /q`
-
-* NOTE: be careful with `shell rmdir "mydir" /s /q`: this is recursive deletion 
-
 program drop _all
  
 di "`c(sysdir_plus)'"
@@ -32,7 +25,7 @@ else if "`c(os)'"=="Unix" {
 	local deletion1 `"shell rm -r -f `custom_lib'"'
 	local deletion2 `"shell rm -r -f wd"'
 	
-	* Remove default NBER paths to ensure test script uses development version
+	* Remove default NBER paths to ensure test script uses development version of ftools
 	adopath - /home/site/etc/stata/ado.nber
 }
 

--- a/test/compile.do
+++ b/test/compile.do
@@ -11,8 +11,36 @@ assert "`c(os)'"=="Windows"
 di "`c(sysdir_plus)'"
 di "`c(sysdir_personal)'"
 
+* Because we are changing adopaths in this test script, reinstall tools from source each time
 local netfrom "https://github.com/reifjulian/ftools/raw/master/src/"
 
+* Custom installation and deletion commands differ by OS
+* CAUTION: these commands include a recursive deletion of a directory (temporarily) created by this test script
+if "`c(os)'"=="Windows" {
+	local custom_lib "C:/custom_lib"
+	local deletion1 `"shell rmdir "`custom_lib'" /s /q"'
+	local deletion2 `"shell rmdir "wd" /s /q"'
+}
+
+else if "`c(os)'"=="OsX" {
+	local custom_lib ""
+	local deletion1 `"shell rmdir "`custom_lib'" /s /q"'
+	local deletion2 `"shell rmdir "wd" /s /q"'
+	error 1
+}
+
+else if "`c(os)'"=="unix" {
+	local custom_lib ""
+	local deletion1 `"shell rmdir "`custom_lib'" /s /q"'
+	local deletion2 `"shell rmdir "wd" /s /q"'
+	error 1
+}
+
+else error 1
+
+***********
+* RUN TEST
+***********
 
 * Installing to PERSONAL
 net set ado "`c(sysdir_personal)'"
@@ -36,17 +64,16 @@ ado uninstall ftools , from("`c(sysdir_plus)'")
 rm "`c(sysdir_plus)'/l/lftools.mlib"
 
 
-
 * Installing to a custom directory
-mkdir "C:/custom_lib"
-adopath ++ "C:/custom_lib"
-net set ado "C:/custom_lib"
+mkdir "`custom_lib'"
+adopath ++ "`custom_lib'"
+net set ado "`custom_lib'"
 cap ado uninstall ftools
 net install ftools, from(`"`netfrom'"')
 mata: mata mlib index
 ftools, compile
-confirm file "C:/custom_lib/l/lftools.mlib"
-shell rmdir "C:/custom_lib" /s /q
+confirm file "`custom_lib'/l/lftools.mlib"
+`deletion1'
 
 * If there is nothing available (besides BASE/SITE/OLDPLACE, which are ignored), install to local dir
 adopath - 1
@@ -61,4 +88,4 @@ mata: mata mlib index
 ftools, compile
 confirm file "`pwd'/l/lftools.mlib"
 cd ..
-shell rmdir "wd" /s /q
+`deletion2'

--- a/test/compile.do
+++ b/test/compile.do
@@ -6,7 +6,6 @@
 * NOTE: be careful with `shell rmdir "mydir" /s /q`: this is recursive deletion 
 
 program drop _all
-assert "`c(os)'"=="Windows"
  
 di "`c(sysdir_plus)'"
 di "`c(sysdir_personal)'"
@@ -22,18 +21,20 @@ if "`c(os)'"=="Windows" {
 	local deletion2 `"shell rmdir "wd" /s /q"'
 }
 
-else if "`c(os)'"=="OsX" {
+else if "`c(os)'"=="OSX" {
 	local custom_lib ""
-	local deletion1 `"shell rmdir "`custom_lib'" /s /q"'
-	local deletion2 `"shell rmdir "wd" /s /q"'
+	local deletion1 `"shell rm -r "`custom_lib'""'
+	local deletion2 `"shell rm -r "wd""'
 	error 1
 }
 
-else if "`c(os)'"=="unix" {
-	local custom_lib ""
-	local deletion1 `"shell rmdir "`custom_lib'" /s /q"'
-	local deletion2 `"shell rmdir "wd" /s /q"'
-	error 1
+else if "`c(os)'"=="Unix" {
+	local custom_lib "~/custom_lib"
+	local deletion1 `"shell rm -r -f `custom_lib'"'
+	local deletion2 `"shell rm -r -f wd"'
+	
+	* Remove default NBER paths to ensure test script uses development version
+	adopath - /home/site/etc/stata/ado.nber
 }
 
 else error 1

--- a/test/compile.do
+++ b/test/compile.do
@@ -6,10 +6,6 @@ di "`c(sysdir_personal)'"
 local netfrom "https://github.com/reifjulian/ftools/raw/master/src/"
 
 
-*cap mkdir "$MyProject/scripts/libraries"
-*cap mkdir "$MyProject/scripts/libraries/stata"
-
-
 * Installing to PERSONAL
 net set ado "`c(sysdir_personal)'"
 cap ado uninstall ftools
@@ -41,16 +37,17 @@ net install ftools, from(`"`netfrom'"')
 mata: mata mlib index
 ftools, compile
 confirm file "C:/custom_lib/l/lftools.mlib"
-erase "C:/custom_lib"
+shell rmdir "C:/custom_lib" /s /q
 
 * If there is nothing available (besides BASE/SITE/OLDPLACE, which are ignored), install to local dir
 adopath - 1
-mkdir workdir
-cd workdir
-net set ado "`c(pwd)'"
+adopath - PLUS
+mkdir wd
+cd wd
+local pwd "`c(pwd)'"
+net set ado "`pwd'"
 cap ado uninstall ftools
 net install ftools, from(`"`netfrom'"')
 mata: mata mlib index
 ftools, compile
-confirm file "`c(pwd)'/l/lftools.mlib"
-erase "C:/custom_lib"
+confirm file "`pwd'/l/lftools.mlib"

--- a/test/compile.do
+++ b/test/compile.do
@@ -1,24 +1,36 @@
 
 program drop _all
+di "`c(sysdir_plus)'"
+di "`c(sysdir_personal)'"
 
-
+local netfrom "https://github.com/reifjulian/ftools/raw/master/src/"
 
 
 *cap mkdir "$MyProject/scripts/libraries"
 *cap mkdir "$MyProject/scripts/libraries/stata"
+
+
+* Installing to PERSONAL
 net set ado "`c(sysdir_personal)'"
-
-
-*cap ado uninstall ftools, replace
-*net install ftools, from("https://github.com/reifjulian/ftools/raw/master/src/")
-*net install ftools, from(https://github.com/sergiocorreia/ftools/raw/master/src/)
-*mata: mata mlib index
-
+cap ado uninstall ftools
+net install ftools, from(`"`netfrom'"')
+mata: mata mlib index
 ftools, compile
+confirm file "`c(sysdir_personal)'/l/lftools.mlib"
+ado uninstall ftools , from("`c(sysdir_personal)'")
 
-di "`c(sysdir_plus)'"
-di "`c(sysdir_personal)'"
-di "`c(sysdir_oldplace)'"
 
-mata : st_numscalar("OK", direxists("C:\ado\personal\\"))
-di OK
+* Installing to PLUS
+adopath - PERSONAL
+net set ado "`c(sysdir_plus)'"
+cap ado uninstall ftools
+net install ftools, from(`"`netfrom'"')
+mata: mata mlib index
+ftools, compile
+confirm file "`c(sysdir_plus)'/l/lftools.mlib"
+ado uninstall ftools , from("`c(sysdir_plus)'")
+
+
+
+
+

--- a/test/compile.do
+++ b/test/compile.do
@@ -43,6 +43,24 @@ else error 1
 * RUN TEST
 ***********
 
+* Robustness test: user adds nonsense paths to adopath (these should be ignored)
+mkdir "`custom_lib'"
+adopath ++ "`custom_lib'"
+net set ado "`custom_lib'"
+cap ado uninstall ftools
+net install ftools, from(`"`netfrom'"')
+mata: mata mlib index
+adopath ++ "C:/does_not_exist"
+adopath ++ "~32"
+adopath ++ `"dfh"i"'
+adopath + "z"
+
+ftools, compile
+confirm file "`custom_lib'/l/lftools.mlib"
+`deletion1'
+
+stop
+
 * Installing to PERSONAL
 net set ado "`c(sysdir_personal)'"
 cap ado uninstall ftools
@@ -76,7 +94,7 @@ ftools, compile
 confirm file "`custom_lib'/l/lftools.mlib"
 `deletion1'
 
-* If there is nothing available (besides BASE/SITE/OLDPLACE, which are ignored), install to local dir
+* If there is nothing available (besides BASE/SITE/OLDPLACE, which are ignored), install to current working dir
 adopath - 1
 adopath - PLUS
 mkdir wd
@@ -90,3 +108,6 @@ ftools, compile
 confirm file "`pwd'/l/lftools.mlib"
 cd ..
 `deletion2'
+
+
+

--- a/test/compile.do
+++ b/test/compile.do
@@ -1,5 +1,13 @@
 
+* Note: This test script won't run on Mac or Linux because:
+* (1) creation of directory "C:/custom_lib"
+* (2) deletion of directories using `shell rmdir "mydir" /s /q`
+
+* NOTE: be careful with `shell rmdir "mydir" /s /q`: this is recursive deletion 
+
 program drop _all
+assert "`c(os)'"=="Windows"
+ 
 di "`c(sysdir_plus)'"
 di "`c(sysdir_personal)'"
 
@@ -14,7 +22,7 @@ mata: mata mlib index
 ftools, compile
 confirm file "`c(sysdir_personal)'/l/lftools.mlib"
 ado uninstall ftools , from("`c(sysdir_personal)'")
-
+rm "`c(sysdir_personal)'/l/lftools.mlib"
 
 * Installing to PLUS
 adopath - PERSONAL
@@ -52,3 +60,5 @@ net install ftools, from(`"`netfrom'"')
 mata: mata mlib index
 ftools, compile
 confirm file "`pwd'/l/lftools.mlib"
+cd ..
+shell rmdir "wd" /s /q

--- a/test/compile.do
+++ b/test/compile.do
@@ -1,0 +1,24 @@
+noi cscript "ftools: compile" adofile ftools
+
+
+
+
+
+
+
+*cap mkdir "$MyProject/scripts/libraries"
+*cap mkdir "$MyProject/scripts/libraries/stata"
+*net set ado "$MyProject/scripts/libraries/stata"
+
+
+cap ado uninstall ftools, replace
+
+* Install latest developer's version of the package from GitHub
+foreach p in ftools {
+	net install `p', from("https://raw.githubusercontent.com/reifjulian/`p'/master") replace
+}
+
+
+di "`c(sysdir_plus)'"
+di "`c(sysdir_personal)'"
+di "`c(sysdir_oldplace)'"

--- a/test/compile.do
+++ b/test/compile.do
@@ -32,5 +32,12 @@ ado uninstall ftools , from("`c(sysdir_plus)'")
 
 
 
-
-
+* Installing to a custom directory
+mkdir "C:/custom_lib"
+adopath ++ "C:/custom_lib"
+net set ado "C:/custom_lib"
+cap ado uninstall ftools
+net install ftools, from(`"`netfrom'"')
+mata: mata mlib index
+ftools, compile
+confirm file "C:/custom_lib/l/lftools.mlib"

--- a/test/compile.do
+++ b/test/compile.do
@@ -1,23 +1,20 @@
-noi cscript "ftools: compile" adofile ftools
 
-
-
+program drop _all
 
 
 
 
 *cap mkdir "$MyProject/scripts/libraries"
 *cap mkdir "$MyProject/scripts/libraries/stata"
-*net set ado "$MyProject/scripts/libraries/stata"
+net set ado "`c(sysdir_personal)'"
 
 
-cap ado uninstall ftools, replace
+*cap ado uninstall ftools, replace
+*net install ftools, from("https://github.com/reifjulian/ftools/raw/master/src/")
+net install ftools, from(https://github.com/sergiocorreia/ftools/raw/master/src/)
+mata: mata mlib index
 
-* Install latest developer's version of the package from GitHub
-foreach p in ftools {
-	net install `p', from("https://raw.githubusercontent.com/reifjulian/`p'/master") replace
-}
-
+ftools, compile
 
 di "`c(sysdir_plus)'"
 di "`c(sysdir_personal)'"


### PR DESCRIPTION
`ftools, compile` will now compile to either PERSONAL, PLUS, or any custom folder that is listed prior to these in S_ADO. As before, it will never compile to BASE/SITE/OLDPLACE (unless these are listed separately as a custom folder). If it fails, it then tries to save to working directory, regardless of whether that is listed in S_ADO.

See `/test/compile.do` for some test code. I confirmed this code ran on mac, unix, and windows.

It would be ideal to have `ftools` compile to where `net set` points to. However, while `net query` displays the relevant folder, it doesn't save it, and from what I can tell it is not accessible unfortunately.

So, best practice for a user who wants a custom library would be use `net set` AND `adopath++`, then install `ftools` and also call `ftools, compile`. 